### PR TITLE
Emptied payment checkout method parameters

### DIFF
--- a/Services/PaypalWebCheckoutManager.php
+++ b/Services/PaypalWebCheckoutManager.php
@@ -174,7 +174,7 @@ class PaypalWebCheckoutManager
             $parameters['notify_version'],
             $parameters['payer_status'],
             $parameters['business'],
-            $parameters['quantity'],
+            null,
             $parameters['verify_sign'],
             $parameters['payer_email'],
             $parameters['txn_id'],
@@ -182,9 +182,9 @@ class PaypalWebCheckoutManager
             $parameters['receiver_email'],
             null,
             $parameters['txn_type'],
-            $parameters['item_name'],
+            null,
             $parameters['mc_currency'],
-            $parameters['item_number'],
+            null,
             $parameters['test_ipn'],
             $parameters['ipn_track_id']
         );
@@ -241,7 +241,6 @@ class PaypalWebCheckoutManager
     protected function checkResultParameters(array $parameters)
     {
         $requiredParameters = array(
-            'item_number',
             'payment_status'
         );
 


### PR DESCRIPTION
`PaypalWebCheckoutMethod` is not useful right now since some parameters, like `quantity` or `item_name` can be appended with numbers (i.e. `item_name1` or `quantity1`) when the originating form uses more than one item per paypal checkout.
It is better to remove it until we discuss the minimum set of attributes that should be passed to the `PaypalWebCheckoutMethod`